### PR TITLE
:construction_worker: ci: disable provider upgrade automerge

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -44,9 +44,16 @@ publish:
 # Disables a pulumi-internal-only step for running create_docs_build during the release
 publishRegistry: false
 
+# checkUpstreamUpgrade determines whether we run the upstream upgrade job for bridged providers.
+# Set to false for providers that cannot be upgraded, e.g. because of archived upstream or a license conflict.
 checkUpstreamUpgrade: true
 
+# Delete existing files within the .github/workflows directory, except where the file begins with the name of the provider
+# (e.g. `aws-*`) which are considered provider-specific workflows.
 clean-github-workflows: false
+
+# Whether we automatically merge upstream provider upgrades.
+autoMergeProviderUpgrades: false
 
 # Enables ESC for CI secrets. Optional.
 esc:

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -92,7 +92,7 @@ jobs:
           kind: provider
           email: bot@pulumi.com
           username: pulumi-bot
-          automerge: true
+          automerge: false
           target-version: ${{ steps.target_version.outputs.version }}
           allow-missing-docs: true
         env:


### PR DESCRIPTION
## Description

- Disables the terraform provider `upgrade_config` workflow automerging

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [X] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [X] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [X] I have added tests or explained why they are not needed
* [X] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
