### PR TITLE
🐛 fix: set new config attributes alongside deprecated ones

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -119,12 +119,23 @@ func providerConfigureClient(d *schema.ResourceData) (any, error) {
 	}
 	if region, ok := d.GetOk("region"); ok {
 		config.Region = region.(string)
+		config.APIRegion = region.(string)
 	}
 	endpointsSet := d.Get("endpoints").(*schema.Set)
 
 	for _, endpointsSetI := range endpointsSet.List() {
 		endpoints := endpointsSetI.(map[string]any)
 		config.Endpoints["api"] = endpoints["api"].(string)
+		config.APIEndpoint = endpoints["api"].(string)
+	}
+	if x509CertPath, ok := d.GetOk("x509_cert_path"); ok {
+		config.APIX509Cert = x509CertPath.(string)
+	}
+	if x509KeyPath, ok := d.GetOk("x509_key_path"); ok {
+		config.APIX509Key = x509KeyPath.(string)
+	}
+	if insecure, ok := d.GetOk("insecure"); ok {
+		config.APIInsecure = insecure.(bool)
 	}
 
 	return config.Client()


### PR DESCRIPTION
## Description

The terraform provider configuration schema changed and deprecated multiple client attributes (`region` and more, see https://github.com/outscale/terraform-provider-outscale/pull/681). Pulumi overrides the Client configuration and only setted the deprecated attributes, which are not accessed by the provider.

This PR fixes this behavior by setting both attributes to the Client to be backward compatible with Pulumi configuration.

Fixes: #60

## Type of Change

Please check the relevant option(s):

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [X] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [X] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [ ] I have added tests or explained why they are not needed
* [ ] I have updated relevant documentation (README, examples, etc.)
* [X] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [X] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
